### PR TITLE
Fix use_pretrained overriding bug in 01-Classification/Model.py

### DIFF
--- a/AWS/01-Classification/Model.py
+++ b/AWS/01-Classification/Model.py
@@ -64,7 +64,7 @@ def Create_Model_Optimizer_Criterion(n_classes, feature_extract = True, use_pret
         criterion : an object of torch.nn that is used to represent a loss function used for training torch model.
     '''
     
-    model = Initialize_Resnet18_model(n_classes, feature_extract, use_pretrained=True)
+    model = Initialize_Resnet18_model(n_classes, feature_extract, use_pretrained)
     
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")    ## set GPU device    
     # Send the model to GPU

--- a/GoogleCloud/01-Classification/Model.py
+++ b/GoogleCloud/01-Classification/Model.py
@@ -64,7 +64,7 @@ def Create_Model_Optimizer_Criterion(n_classes, feature_extract = True, use_pret
         criterion : an object of torch.nn that is used to represent a loss function used for training torch model.
     '''
     
-    model = Initialize_Resnet18_model(n_classes, feature_extract, use_pretrained=True)
+    model = Initialize_Resnet18_model(n_classes, feature_extract, use_pretrained)
     
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")    ## set GPU device    
     # Send the model to GPU


### PR DESCRIPTION
## Pull Request Template

### Description
<!-- Provide a description of your changes here. If this PR is related to an issue, list the issue number/name here -->
In `01-Classification/Model.py`, within the `Create_Model_Optimizer_Criterion()` function, the `use_pretrained` argument was being explicitly set to `True` when calling `Initialize_Resnet18_model()`, overriding the function’s own `use_pretrained` parameter. I removed the hardcoded `True` so that the function now correctly uses its `use_pretrained` argument.

### Assignee
<!-- Mention the GitHub username of the user you want to assign this PR to -->
Assignees: @kyleoconnell-NIH and @rosscampbellNIH

## PR checklist
*Please ensure the following:*
- [X] This comment contains a description of changes (with reason).
- [X] All changes were tested.
- [ ] If you've fixed a bug mention the issue number/name.
- [ ] Apply appropriate tags (e.g. documentation, bug)
